### PR TITLE
ビルドにWindows 11 SDKを使わないようにする

### DIFF
--- a/ci/build_installer.ps1
+++ b/ci/build_installer.ps1
@@ -41,11 +41,9 @@ if ($Ref -eq 'v3.8.12') {
 
 # Avoid a build error for version 3.7 and 3.8 (ref. https://github.com/kai2nenobu/win-python-installer/issues/6)
 if ($Ref -match '^v?3\.[78]') {
-  'Overwrite python.props by one on 3.9 branch.'
+  'Avoid Windows 11 SDK in branch 3.7 and 3.8'
   Push-Location cpython
-  curl.exe -sSL https://github.com/python/cpython/raw/3.9/PCbuild/python.props > PCbuild/python.props
-  git add .
-  git -c user.name=dummy -c 'user.email=dummy@example.com' commit -m 'Overwrite python.props by one on 3.9 branch.'
+  git -c user.name=dummy -c 'user.email=dummy@example.com' am ..\patch\avoid_win11_sdk.patch
   Pop-Location
 }
 

--- a/ci/build_installer.ps1
+++ b/ci/build_installer.ps1
@@ -39,6 +39,16 @@ if ($Ref -eq 'v3.8.12') {
   Pop-Location
 }
 
+# Avoid a build error for version 3.7 and 3.8 (ref. https://github.com/kai2nenobu/win-python-installer/issues/6)
+if ($Ref -match '^v?3\.[78]') {
+  'Overwrite python.props by one on 3.9 branch.'
+  Push-Location cpython
+  curl.exe -sSL https://github.com/python/cpython/raw/3.9/PCbuild/python.props > PCbuild/python.props
+  git add .
+  git -c user.name=dummy -c 'user.email=dummy@example.com' commit -m 'Overwrite python.props by one on 3.9 branch.'
+  Pop-Location
+}
+
 # Build installer
 
 cmd /c cpython\Tools\msi\buildrelease.bat @BuildOptions

--- a/patch/avoid_win11_sdk.patch
+++ b/patch/avoid_win11_sdk.patch
@@ -1,0 +1,26 @@
+From 549382f2394d4bafbbf22080f65e20d677bb977c Mon Sep 17 00:00:00 2001
+From: Steve Dower <steve.dower@python.org>
+Date: Thu, 16 Sep 2021 19:29:32 +0100
+Subject: [PATCH] Avoid automatically selecting the Windows 11 SDK preview when building
+
+Co-authored-by: Steve Dower <steve.dower@python.org>
+
+---
+ PCbuild/python.props | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/PCbuild/python.props b/PCbuild/python.props
+index 1034e7f..e6b2aa9 100644
+--- a/PCbuild/python.props
++++ b/PCbuild/python.props
+@@ -80,6 +80,9 @@
+     <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
+     <_RegistryVersion Condition="$(_RegistryVersion) != '' and !$(_RegistryVersion.EndsWith('.0'))">$(_RegistryVersion).0</_RegistryVersion>
+ 
++    <!-- Avoid upgrading to Windows 11 SDK for now, but assume the latest Win10 SDK is installed -->
++    <_RegistryVersion Condition="$([System.Version]::Parse($(_RegistryVersion))) >= $([System.Version]::Parse(`10.0.22000.0`))">10.0.19041.0</_RegistryVersion>
++
+     <!-- The minimum allowed SDK version to use for building -->
+     <DefaultWindowsSDKVersion>10.0.10586.0</DefaultWindowsSDKVersion>
+     <DefaultWindowsSDKVersion Condition="$([System.Version]::Parse($(_RegistryVersion))) > $([System.Version]::Parse($(DefaultWindowsSDKVersion)))">$(_RegistryVersion)</DefaultWindowsSDKVersion>
+


### PR DESCRIPTION
3.7、3.8ブランチでのビルドエラーを回避するため、ブランチ3.9のpython.propsで
上書きするようにした。

Fix #6 