### PR TITLE
Avoid a build error for exe.wixproj between version 3.7 and 3.10

### DIFF
--- a/ci/build_installer.ps1
+++ b/ci/build_installer.ps1
@@ -48,7 +48,14 @@ if ($Ref -match '^v?3\.[78]') {
   Pop-Location
 }
 
-# Build installer
+# Avoid a build error for exe.wixproj between version 3.7 and 3.10 (ref. https://github.com/kai2nenobu/win-python-installer/issues/28)
+if ($Ref -match '^v?3\.([789]|10)') {
+  'Avoid a build error for exe.wixproj between version 3.7 and 3.10'
+  Push-Location cpython
+  git apply ..\patch\avoid_pylauncher_311_error.patch
+  Pop-Location
+}
 
+# Build installer
 cmd /c cpython\Tools\msi\buildrelease.bat @BuildOptions
 if ($LASTEXITCODE -gt 0) { exit $LASTEXITCODE }

--- a/ci/build_installer.ps1
+++ b/ci/build_installer.ps1
@@ -1,4 +1,4 @@
-
+﻿
 [CmdletBinding()]
 Param(
   [Parameter(Position=0)]
@@ -40,9 +40,9 @@ if ($Ref -notmatch '^v?3\.[67]') {
   python -m pip install -r ./cpython/Doc/requirements.txt
 }
 
-# Avoid a build error for version 3.7 and 3.8 (ref. https://github.com/kai2nenobu/win-python-installer/issues/6)
-if ($Ref -match '^v?3\.[78]') {
-  'Avoid Windows 11 SDK in branch 3.7 and 3.8'
+# Avoid a build error for version 3.7 (ref. https://github.com/kai2nenobu/win-python-installer/issues/6)
+if ($Ref -match '^v?3\.7') {
+  'Avoid Windows 11 SDK in branch 3.7'
   Push-Location cpython
   git -c user.name=dummy -c 'user.email=dummy@example.com' am ..\patch\avoid_win11_sdk.patch
   Pop-Location

--- a/ci/build_installer.ps1
+++ b/ci/build_installer.ps1
@@ -1,4 +1,4 @@
-﻿
+
 [CmdletBinding()]
 Param(
   [Parameter(Position=0)]
@@ -53,6 +53,8 @@ if ($Ref -match '^v?3\.([789]|10)') {
   'Avoid a build error for exe.wixproj between version 3.7 and 3.10'
   Push-Location cpython
   git apply ..\patch\avoid_pylauncher_311_error.patch
+  git add --update .
+  git -c user.name=dummy -c 'user.email=dummy@example.com' commit -m 'Avoid a build error for exe.wixproj between version 3.7 and 3.10'
   Pop-Location
 }
 

--- a/patch/avoid_pylauncher_311_error.patch
+++ b/patch/avoid_pylauncher_311_error.patch
@@ -1,0 +1,11 @@
+--- a/Tools/msi/exe/exe.wixproj
++++ b/Tools/msi/exe/exe.wixproj
+@@ -36,7 +36,7 @@
+         <ItemGroup>
+             <HostPython Include="$(ExternalsDir)python*\tools\python.exe" />
+             <HostPython Include="@(HostPython)" Condition="Exists(%(FullPath))" />
+-            <HostPython Include="py" Condition="@(HostPython) == ''" />
++            <HostPython Include="py.exe" Condition="@(HostPython) == ''" />
+         </ItemGroup>
+         <PropertyGroup>
+             <HostPython>@(HostPython)</HostPython>


### PR DESCRIPTION
Fix #28 