### PR TITLE
Drop Python 3.7 from security fix releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - version: '3.7'
-          branch:  '3.7'
-          os: windows-2019
         - version: '3.8'
           branch:  '3.8'
           os: windows-2019

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 |       3.10 | [3.10.12](https://github.com/kai2nenobu/win-python-installer/releases/tag/v3.10.12) | 2023-06-06 |             |
 |        3.9 | [3.9.17](https://github.com/kai2nenobu/win-python-installer/releases/tag/v3.9.17) | 2023-06-06 |             |
 |        3.8 | [3.8.17](https://github.com/kai2nenobu/win-python-installer/releases/tag/v3.8.17) | 2023-06-06 |             |
-|        3.7 | [3.7.17](https://github.com/kai2nenobu/win-python-installer/releases/tag/v3.7.17) | 2023-06-05 |             |
+|        3.7 | [3.7.17](https://github.com/kai2nenobu/win-python-installer/releases/tag/v3.7.17) | 2023-06-05 | ✓           |
 |        3.6 | [3.6.15](https://github.com/kai2nenobu/win-python-installer/releases/tag/v3.6.15) | 2021-09-04 | ✓           |
 
 リリース一覧は[こちら](https://github.com/kai2nenobu/win-python-installer/releases)。


### PR DESCRIPTION
Resolve #20 