### PR TITLE
Fix build failure on building python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
       run: cmd /c set
     - uses: actions/setup-python@v5
       # Use a specific version as HOST_PYTHON
+      name: Use Python ${{ matrix.HOST_PYTHON }} as HOST_PYTHON
       id: host_python
       with:
         python-version: ${{ matrix.HOST_PYTHON }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         - version: '3.8'
           branch:  '3.8'
           os: windows-2019
+          HOST_PYTHON:  '3.8'
         - version: '3.9'
           branch:  '3.9'
           os: windows-2019
@@ -47,10 +48,18 @@ jobs:
     - uses: actions/checkout@v4
     - name: Show env
       run: cmd /c set
+    - uses: actions/setup-python@v5
+      # Use a specific version as HOST_PYTHON
+      id: host_python
+      with:
+        python-version: ${{ matrix.HOST_PYTHON }}
+      if: matrix.HOST_PYTHON
     - name: Build Installer
       run: |
         powershell -NoProfile -File .\ci\build_installer.ps1 `
           -OutDirectory "${{ github.workspace }}\dist" "${{ matrix.branch }}"
+      env:
+        HOST_PYTHON: ${{ matrix.HOST_PYTHON && steps.host_python.outputs.python-path || '' }}
     - name: Check built installer
       run: |
         Get-ChildItem -R 'dist'


### PR DESCRIPTION
Use python 3.8 as HOST_PYTHON to build python 3.8